### PR TITLE
Fix duplicate year selectbox keys in stock_datagrid

### DIFF
--- a/check data use/stock_datagrid.py
+++ b/check data use/stock_datagrid.py
@@ -250,28 +250,6 @@ with tab_sales:
             )
 
         df_d2 = filt(df, desc=desc_sel, code=code_sel)
-        with col_r:
-            year_opts = sorted([y for y in df_d2["Year"].unique() if y])
-            old_year = ss.get("year", ALL)
-            if old_year not in year_opts and old_year != ALL:
-                year_opts.append(old_year)
-            year_sel = st.selectbox(
-                "Step 3：年份", [ALL] + year_opts, key="year"
-            )
-
-            df_d3 = filt(df_d2, year=year_sel)
-
-            MONTH_ORDER = [
-                "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-            ]
-            month_opts = [m for m in MONTH_ORDER if m in df_d3["Month"].unique()]
-            old_month = ss.get("month", ALL)
-            if old_month not in month_opts and old_month != ALL:
-                month_opts.append(old_month)
-            month_sel = st.selectbox(
-                "Step 4：月份", [ALL] + month_opts, key="month"
-            )
 
         # -------- Step-3 / 4  年份 & 月份 --------
         col_year, col_month = st.columns(2)
@@ -301,47 +279,6 @@ with tab_sales:
 
         # -------- Step-5 / 6  客户 & 门店 --------
         col_cust, col_out = st.columns(2)
-
-        with col_cust:
-            cust_opts = sorted(df_d4["Customer"].dropna().unique())
-            old_cust = ss.get("cust", ALL)
-            if old_cust not in cust_opts and old_cust != ALL:
-                cust_opts.append(old_cust)
-            cust_sel = st.selectbox(
-                "Step 5：客户", [ALL] + cust_opts, key="cust"
-            )
-
-        df_d5 = filt(df_d4, cust=cust_sel)
-
-        with col_out:
-            outlet_opts = sorted(df_d5["Outlet"].dropna().unique())
-            old_outlet = ss.get("outlet", ALL)
-            if old_outlet not in outlet_opts and old_outlet != ALL:
-                outlet_opts.append(old_outlet)
-            outlet_sel = st.selectbox(
-                "Step 6：门店", [ALL] + outlet_opts, key="outlet"
-            )
-
-        final_df = filt(df_d5, outlet=outlet_sel)
-
-        # -------- 结果区域 --------
-        if desc_sel == ALL:
-            st.info("👉 先选“产品名称”再查看数据")
-        elif final_df.empty:
-            st.warning("当前筛选无数据")
-        else:
-            tbl = (
-                final_df[["Customer", "Outlet", "Date", "Qty in Ctns", "Qty in Pcs"]]
-                .groupby(["Customer", "Outlet", "Date"], as_index=False)
-                .sum()
-                .rename(columns={"Qty in Ctns": "CTN", "Qty in Pcs": "PCS"})
-                .astype({"CTN": int, "PCS": int})
-                .sort_values("Date")
-            )
-            tbl.loc["总计"] = ["", "", "总计", tbl["CTN"].sum(), tbl["PCS"].sum()]
-
-            show_df(tbl)
-
 
         with col_cust:
             cust_opts = sorted(df_d4["Customer"].dropna().unique())
@@ -378,10 +315,13 @@ with tab_sales:
                        tbl["CTN"].sum(), tbl["PCS"].sum()]
 
             # -------- 排序选项 --------
+            sort_options = [c for c in tbl.columns if c != ""]
+            default_idx = sort_options.index("Date") if "Date" in sort_options else 0
             sort_col2 = st.selectbox(
                 "排序字段",
-                [c for c in tbl.columns if c != ""],
+                sort_options,
                 key="sale_sort_col",
+                index=default_idx,
             )
             asc2 = st.radio(
                 "排序方式", ["升序", "降序"], key="sale_sort_dir", horizontal=True


### PR DESCRIPTION
## Summary
- remove duplicated year and month selectboxes
- clean up duplicated customer/outlet selection block
- ensure sort field defaults to Date

## Testing
- `python -m py_compile 'check data use/stock_datagrid.py'`
