### PR TITLE
Improve chapter detection logic

### DIFF
--- a/txttoepub/txt_to_epub_github.py
+++ b/txttoepub/txt_to_epub_github.py
@@ -66,7 +66,13 @@ def clean_text(text: str) -> str:
     return ''.join(allowed_chars)
 
 
-def is_chapter_heading(line: str) -> bool:
+CHAPTER_TITLE_RE = re.compile(
+    r"^第[0-9零一二三四五六七八九十百千万〇两]+(?:卷|季|集|部|册)?"
+    r"(?:第[0-9零一二三四五六七八九十百千万〇两]+)?(?:章|回|篇|节|话).*"
+)
+
+
+def is_chapter_heading(line: str, pattern: re.Pattern = CHAPTER_TITLE_RE) -> bool:
     """Return True if *line* looks like a chapter heading."""
     text = clean_text(line).strip()
     if not text or len(text) > 50:
@@ -76,12 +82,7 @@ def is_chapter_heading(line: str) -> bool:
     if norm in ("序", "序章", "楔子"):
         return True
 
-    pat1 = (
-        r"^第[0-9零一二三四五六七八九十百千万〇两]+(?:卷|季|集|部|册)?"
-        r"(?:第[0-9零一二三四五六七八九十百千万〇两]+)?(?:章|回|篇|节|话).*"
-    )
-    pat2 = r"^[0-9一二三四五六七八九十百千万〇两]{1,4}[、.．]\S+"
-    return bool(re.match(pat1, norm) or re.match(pat2, text))
+    return bool(pattern.match(norm))
 
 
 def detect_author(file_path: str, max_lines: int = 20) -> str:


### PR DESCRIPTION
## Summary
- refine chapter heading detection to avoid subheading confusion

## Testing
- `python3 -m py_compile txttoepub/txt_to_epub_github.py`

------
https://chatgpt.com/codex/tasks/task_b_683054ddb5ac8330bdab27537c1632f7