### PR TITLE
Improve precad view switching

### DIFF
--- a/function/precad.py
+++ b/function/precad.py
@@ -1,6 +1,6 @@
 import matplotlib
-matplotlib.rcParams['font.family'] = 'Microsoft YaHei'
-matplotlib.rcParams['axes.unicode_minus'] = False
+matplotlib.rcParams["font.family"] = "Microsoft YaHei"
+matplotlib.rcParams["axes.unicode_minus"] = False
 
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Button, RadioButtons
@@ -44,8 +44,13 @@ def draw_2d(ax, mode='custom'):
             {"xy": (x3, y3), "l": l3, "w": w3, "ec": "g", "label": "新新物体"},
             {"xy": (x4, y4), "l": l4, "w": w4, "ec": "orange", "label": "右下角模型"},
         ]
+        handles = []
+        labels = []
         for r in rects:
-            ax.add_patch(plt.Rectangle(r["xy"], r["l"], r["w"], fill=None, edgecolor=r["ec"], lw=2))
+            patch = plt.Rectangle(r["xy"], r["l"], r["w"], fill=None, edgecolor=r["ec"], lw=2)
+            ax.add_patch(patch)
+            handles.append(patch)
+            labels.append(r["label"])
         def annotate_rect(x, y, l, w, color):
             ax.text(x + l/2, y + w, f"{l} mm", color=color, va="bottom", ha="center", fontsize=10, fontweight="bold")
             ax.text(x + l, y + w/2, f"{w} mm", color=color, va="center", ha="left", fontsize=10, fontweight="bold")
@@ -53,17 +58,23 @@ def draw_2d(ax, mode='custom'):
         annotate_rect(x2, y2, l2, w2, "r")
         annotate_rect(x3, y3, l3, w3, "g")
         annotate_rect(x4, y4, l4, w4, "orange")
-        ax.legend([r["label"] for r in rects], loc="upper right", fontsize=10, frameon=True)
+        ax.legend(handles, labels, loc="upper right", fontsize=10, frameon=True)
     elif mode == 'remain':
-        rects = [
-            {"xy": (0, 0), "l": L, "w": W, "ec": "b", "label": "主空间"},
-        ]
+        main_patch = plt.Rectangle((0, 0), L, W, fill=None, edgecolor="b", lw=2)
+        ax.add_patch(main_patch)
+        handles = [main_patch]
+        labels = ["主空间"]
         for block in remain_blocks:
-            ax.add_patch(plt.Rectangle(block["xy"], block["l"], block["w"], fill=None, edgecolor=block["color"], lw=2, linestyle="--"))
-            # 标注
+            patch = plt.Rectangle(block["xy"], block["l"], block["w"], fill=None,
+                                  edgecolor=block["color"], lw=2, linestyle="--")
+            ax.add_patch(patch)
+            handles.append(patch)
+            labels.append(block["label"])
             cx, cy = block["xy"]
-            ax.text(cx + block["l"]/2, cy + block["w"]/2, block["label"], color=block["color"], ha="center", va="center", fontsize=10, fontweight="bold")
-        ax.legend(["主空间"] + [b["label"] for b in remain_blocks], loc="upper right", fontsize=10, frameon=True)
+            ax.text(cx + block["l"] / 2, cy + block["w"] / 2, block["label"],
+                    color=block["color"], ha="center", va="center",
+                    fontsize=10, fontweight="bold")
+        ax.legend(handles, labels, loc="upper right", fontsize=10, frameon=True)
 
 def draw_3d(ax, mode='custom'):
     ax.clear()
@@ -116,7 +127,7 @@ def draw_3d(ax, mode='custom'):
 
 # 界面主逻辑
 fig = plt.figure(figsize=(10, 5))
-plt.subplots_adjust(left=0.2, bottom=0.15, right=0.80)  # 控件区域
+MAIN_REGION = [0.2, 0.15, 0.6, 0.8]
 state = {"view": "custom", "dim": "2d"}
 active_ax = {"ax": None}
 
@@ -126,17 +137,18 @@ ax_radio = plt.axes([0.02, 0.01, 0.16, 0.18])
 radio = RadioButtons(ax_radio, ("定制物体", "剩余空间"), active=0)
 
 def redraw():
-    # 清除旧axes
+    # 清除旧主axes
     if active_ax["ax"] is not None:
-        active_ax["ax"].remove()
+        fig.delaxes(active_ax["ax"])
         active_ax["ax"] = None
+
     # 新建axes并绘图
     if state["dim"] == "2d":
-        ax = fig.add_subplot(111)
+        ax = fig.add_axes(MAIN_REGION)
         draw_2d(ax, mode=state["view"])
         active_ax["ax"] = ax
     else:
-        ax3d = fig.add_subplot(111, projection="3d")
+        ax3d = fig.add_axes(MAIN_REGION, projection="3d")
         draw_3d(ax3d, mode=state["view"])
         active_ax["ax"] = ax3d
     fig.canvas.draw_idle()
@@ -153,7 +165,7 @@ btn.on_clicked(on_toggle)
 radio.on_clicked(on_radio)
 
 # 首次绘制
-ax = fig.add_subplot(111)
+ax = fig.add_axes(MAIN_REGION)
 draw_2d(ax, mode=state["view"])
 active_ax["ax"] = ax
 


### PR DESCRIPTION
## Summary
- stabilize view switching logic with dedicated main axes
- fix legend creation for both custom and remaining spaces
- normalize line endings to Unix format

## Testing
- `python - <<'PY'
import matplotlib
matplotlib.use('Agg')
import function.precad
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_b_684d12f22ffc8324865c9e6ec170c58b