### PR TITLE
Improve precad annotations

### DIFF
--- a/function/precad.py
+++ b/function/precad.py
@@ -1,6 +1,6 @@
 import matplotlib
-matplotlib.rcParams['font.family'] = 'Microsoft YaHei'
-matplotlib.rcParams['axes.unicode_minus'] = False
+matplotlib.rcParams["font.family"] = "Microsoft YaHei"
+matplotlib.rcParams["axes.unicode_minus"] = False
 
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Button, RadioButtons
@@ -21,7 +21,7 @@ remain_blocks = [
     {"xy": (x3+l3, y2), "l": L-(x3+l3), "w": w3, "h": H, "label": "右上剩余空间", "color": "c"},
     # 左下角底边剩余区块
     {"xy": (0, 0), "l": x4, "w": w4, "h": H, "label": "左下剩余空间", "color": "purple"},
-    # 主空间底部剩余区块（去除右下角模型）
+    # 主空间底部剩余区块（去除门口区域）
     {"xy": (x4+l4, 0), "l": L-(x4+l4), "w": w4, "h": H, "label": "底边剩余空间", "color": "lime"},
     # 可根据需求增加更多区块
 ]
@@ -40,30 +40,41 @@ def draw_2d(ax, mode='custom'):
     if mode == 'custom':
         rects = [
             {"xy": (0, 0), "l": L, "w": W, "ec": "b", "label": "主空间"},
-            {"xy": (x2, y2), "l": l2, "w": w2, "ec": "r", "label": "新物体"},
-            {"xy": (x3, y3), "l": l3, "w": w3, "ec": "g", "label": "新新物体"},
-            {"xy": (x4, y4), "l": l4, "w": w4, "ec": "orange", "label": "右下角模型"},
+            {"xy": (x2, y2), "l": l2, "w": w2, "ec": "r", "label": "loft bed"},
+            {"xy": (x3, y3), "l": l3, "w": w3, "ec": "g", "label": "loft bed 的斜梯"},
+            {"xy": (x4, y4), "l": l4, "w": w4, "ec": "brown", "label": "门口"},
         ]
+        handles = []
+        labels = []
         for r in rects:
-            ax.add_patch(plt.Rectangle(r["xy"], r["l"], r["w"], fill=None, edgecolor=r["ec"], lw=2))
+            patch = plt.Rectangle(r["xy"], r["l"], r["w"], fill=None, edgecolor=r["ec"], lw=2)
+            ax.add_patch(patch)
+            handles.append(patch)
+            labels.append(r["label"])
         def annotate_rect(x, y, l, w, color):
             ax.text(x + l/2, y + w, f"{l} mm", color=color, va="bottom", ha="center", fontsize=10, fontweight="bold")
             ax.text(x + l, y + w/2, f"{w} mm", color=color, va="center", ha="left", fontsize=10, fontweight="bold")
         annotate_rect(0, 0, L, W, "b")
         annotate_rect(x2, y2, l2, w2, "r")
         annotate_rect(x3, y3, l3, w3, "g")
-        annotate_rect(x4, y4, l4, w4, "orange")
-        ax.legend([r["label"] for r in rects], loc="upper right", fontsize=10, frameon=True)
+        annotate_rect(x4, y4, l4, w4, "brown")
+        ax.legend(handles, labels, loc="upper right", fontsize=10, frameon=True)
     elif mode == 'remain':
-        rects = [
-            {"xy": (0, 0), "l": L, "w": W, "ec": "b", "label": "主空间"},
-        ]
+        main_patch = plt.Rectangle((0, 0), L, W, fill=None, edgecolor="b", lw=2)
+        ax.add_patch(main_patch)
+        handles = [main_patch]
+        labels = ["主空间"]
         for block in remain_blocks:
-            ax.add_patch(plt.Rectangle(block["xy"], block["l"], block["w"], fill=None, edgecolor=block["color"], lw=2, linestyle="--"))
-            # 标注
+            patch = plt.Rectangle(block["xy"], block["l"], block["w"], fill=None,
+                                  edgecolor=block["color"], lw=2, linestyle="--")
+            ax.add_patch(patch)
+            handles.append(patch)
+            labels.append(block["label"])
             cx, cy = block["xy"]
-            ax.text(cx + block["l"]/2, cy + block["w"]/2, block["label"], color=block["color"], ha="center", va="center", fontsize=10, fontweight="bold")
-        ax.legend(["主空间"] + [b["label"] for b in remain_blocks], loc="upper right", fontsize=10, frameon=True)
+            ax.text(cx + block["l"] / 2, cy + block["w"] / 2, block["label"],
+                    color=block["color"], ha="center", va="center",
+                    fontsize=10, fontweight="bold")
+        ax.legend(handles, labels, loc="upper right", fontsize=10, frameon=True)
 
 def draw_3d(ax, mode='custom'):
     ax.clear()
@@ -102,7 +113,7 @@ def draw_3d(ax, mode='custom'):
         plot_cube_at(ax, (0,0,0), (L,W,H), "b", label=f"{L}×{W}×{H}", alpha=0.07)
         plot_cube_at(ax, (x2,y2,z2), (l2,w2,h2), "r", label=f"{l2}×{w2}×{h2}", alpha=0.18)
         plot_cube_at(ax, (x3,y3,z3), (l3,w3,h3), "g", label=f"{l3}×{w3}×{h3}", alpha=0.18)
-        plot_cube_at(ax, (x4,y4,z4), (l4,w4,h4), "orange", label=f"{l4}×{w4}×{h4}", alpha=0.22)
+        plot_cube_at(ax, (x4,y4,z4), (l4,w4,h4), "brown", label=f"{l4}×{w4}×{h4}", alpha=0.22)
     elif mode == 'remain':
         plot_cube_at(ax, (0,0,0), (L,W,H), "b", label=f"{L}×{W}×{H}", alpha=0.07)
         for block in remain_blocks:
@@ -116,7 +127,7 @@ def draw_3d(ax, mode='custom'):
 
 # 界面主逻辑
 fig = plt.figure(figsize=(10, 5))
-plt.subplots_adjust(left=0.2, bottom=0.15, right=0.80)  # 控件区域
+MAIN_REGION = [0.2, 0.15, 0.6, 0.8]
 state = {"view": "custom", "dim": "2d"}
 active_ax = {"ax": None}
 
@@ -125,18 +136,31 @@ btn = Button(ax_button, "2D/3D切换", color="lightgray", hovercolor="orange")
 ax_radio = plt.axes([0.02, 0.01, 0.16, 0.18])
 radio = RadioButtons(ax_radio, ("定制物体", "剩余空间"), active=0)
 
+# 颜色说明文字（放置在主视图区右侧空白区域）
+color_labels = [
+    ("红色：loft bed", "r"),
+    ("绿色：loft bed 的斜梯", "g"),
+    ("褐色：门口", "brown"),
+]
+_color_texts = []
+for i, (txt, c) in enumerate(color_labels):
+    t = fig.text(0.82, 0.35 + i*0.05, txt, color=c,
+                 ha="left", va="center", fontsize=9)
+    _color_texts.append(t)
+
 def redraw():
-    # 清除旧axes
+    # 清除旧主axes
     if active_ax["ax"] is not None:
-        active_ax["ax"].remove()
+        fig.delaxes(active_ax["ax"])
         active_ax["ax"] = None
+
     # 新建axes并绘图
     if state["dim"] == "2d":
-        ax = fig.add_subplot(111)
+        ax = fig.add_axes(MAIN_REGION)
         draw_2d(ax, mode=state["view"])
         active_ax["ax"] = ax
     else:
-        ax3d = fig.add_subplot(111, projection="3d")
+        ax3d = fig.add_axes(MAIN_REGION, projection="3d")
         draw_3d(ax3d, mode=state["view"])
         active_ax["ax"] = ax3d
     fig.canvas.draw_idle()
@@ -153,7 +177,7 @@ btn.on_clicked(on_toggle)
 radio.on_clicked(on_radio)
 
 # 首次绘制
-ax = fig.add_subplot(111)
+ax = fig.add_axes(MAIN_REGION)
 draw_2d(ax, mode=state["view"])
 active_ax["ax"] = ax
 


### PR DESCRIPTION
## Summary
- rename custom objects in precad
- color mapping labels rendered beside main view
- use brown color for door

## Testing
- `python - <<'PY'
import matplotlib
matplotlib.use('Agg')
from function import precad
print('ok')
PY`


------
https://chatgpt.com/codex/tasks/task_b_684d12f22ffc8324865c9e6ec170c58b